### PR TITLE
Fix consul port mapping for DNS (8600->53/udp)

### DIFF
--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -24,8 +24,8 @@
       - 8302:8302/udp
       - 8400:8400
       - 8500:8500
-      - 8600:8600
-      - 8600:8600/udp
+      - 8600:53
+      - 8600:53/udp
     command:
       -dc "{{ consul_dc | default(dc1) }}"
       -advertise "{{ ansible_eth0.ipv4.address }}"


### PR DESCRIPTION
The program/consul container listens on port 53 for DNS services, so the 8600:8600 port map when running the container doesn't map to a working port.  

```
dig @127.0.0.1 -p 8600  app.service.consul +short
10.180.34.27
10.150.43.184
```
